### PR TITLE
fix(CODE_OF_CONDUCT.md): update email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,4 +9,4 @@ We promise to extend courtesy and respect to everyone involved in this project r
 
 If any member of the community violates this code of conduct, the maintainers of the Angular project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please email us at [conduct@angularjs.org](mailto:coc@angularjs.org).
+If you are subject to or witness unacceptable behavior, or have any other concerns, please email us at [conduct@angular.io](mailto:conduct@angular.io).


### PR DESCRIPTION
This PR updates the email address to conduct@angular.io. 

The new email address was shared by @IgorMinar at ng-conf 2017.

![email](https://cloud.githubusercontent.com/assets/1859381/24826712/6b7bf5e6-1c3c-11e7-9448-7769cfe10852.png)
